### PR TITLE
Fix erroneously blocking for 'read ready' condition when trying to write

### DIFF
--- a/src/inner/unix.rs
+++ b/src/inner/unix.rs
@@ -106,7 +106,7 @@ impl SerialPort {
 		buf: &[u8],
 	) -> Poll<std::io::Result<usize>> {
 		loop {
-			let mut guard = ready!(self.io.poll_read_ready(cx)?);
+			let mut guard = ready!(self.io.poll_write_ready(cx)?);
 			let result = guard.try_io(|inner|{
 				check_ret(unsafe {
 					libc::write(inner.as_raw_fd(), buf.as_ptr().cast(), buf.len())
@@ -125,7 +125,7 @@ impl SerialPort {
 		bufs: &[IoSlice<'_>],
 	) -> Poll<Result<usize, std::io::Error>> {
 		loop {
-			let mut guard = ready!(self.io.poll_read_ready(cx)?);
+			let mut guard = ready!(self.io.poll_write_ready(cx)?);
 			let result = guard.try_io(|inner| {
 				let buf_count = i32::try_from(bufs.len()).unwrap_or(i32::MAX);
 				check_ret(unsafe {


### PR DESCRIPTION
I ran into a tricky bug where writing would fail until it received some data, I think possibly just restricted to the implementation of `AsyncWrite`?

This example shows it:

```diff
diff --git a/Cargo.toml b/Cargo.toml
index b953d90..99ca64c 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ winapi = { version = "0.3.9", features = ["winerror"] }
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros", "rt", "io-std", "io-util"] }
+tokio-util = { version = "0.7.11", features = ["codec"] }
+futures-util = { version = "0.3.30", features = ["sink"] }
 serial2 = { version = "0.2.22", features = ["rs4xx"] }
 
 [package.metadata.docs.rs]
```

`examples/lines-codec.rs`:
```rust
use futures_util::{SinkExt, StreamExt};
use tokio::io::{AsyncReadExt, AsyncWriteExt};

use serial2_tokio::SerialPort;
use tokio_util::codec::{Decoder, LinesCodec};

#[tokio::main(flavor = "current_thread")]
async fn main() {
        if let Err(()) = do_main().await {
                std::process::exit(1);
        }
}

async fn do_main() -> Result<(), ()> {
        let args: Vec<_> = std::env::args().collect();
        if args.len() != 3 {
                let prog_name = args[0].rsplit_once('/').map(|(_parent, name)| name).unwrap_or(&args[0]);
                eprintln!("Usage: {} PORT BAUD", prog_name);
                return Err(());
        }

        let port_name = &args[1];
        let baud_rate: u32 = args[2]
                .parse()
                .map_err(|_| eprintln!("Error: invalid baud rate: {}", args[2]))?;

        let port =
                SerialPort::open(port_name, baud_rate).map_err(|e| eprintln!("Error: Failed to open {}: {}", port_name, e))?;

        let mut line_codec = LinesCodec::new().framed(port);
        line_codec
                .send("D2".to_owned())
                .await
                .expect("failed to send D2 command");
        // line_codec.flush().await.context("failed to flush D2")?;
        eprintln!("D2 command sent");

        while let Some(next) = line_codec.next().await {
                let next_line = next.expect("failed to read line");
                eprintln!("D2 response line: {next_line:?}");
        }
        Ok(())
}
```

Looks like it was just a tricky copy and paste mistake, where the library polls for the 'read ready' state when it needs to poll for 'write ready' instead!