### PR TITLE
Improve main library example.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [fix][patch] Improve example in main library documentation.
+
 # Version 0.1.18 - 2025-09-12
 - [fix][minor] Fix `get_baud_rate()` on Linux with glibc 2.42.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let port = SerialPort::open("/dev/ttyUSB0", 115200)?;
 let mut buffer = [0; 256];
 loop {
     let read = port.read(&mut buffer).await?;
-    port.write(&buffer[..read]).await?;
+    port.write_all(&buffer[..read]).await?;
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! let mut buffer = [0; 256];
 //! loop {
 //!     let read = port.read(&mut buffer).await?;
-//!     port.write(&buffer[..read]).await?;
+//!     port.write_all(&buffer[..read]).await?;
 //! }
 //! # }
 //! ```


### PR DESCRIPTION
Calling `write()` and ignoring the number of written bytes is almost always a bug. Examples should not be promoting code that does this.